### PR TITLE
Api2 deduplicate

### DIFF
--- a/docs/Inputs.rst
+++ b/docs/Inputs.rst
@@ -1,0 +1,86 @@
+Inputs
+======
+
+Data
+++++
+
+The tcrdist2 standard input is a pandas.DataFrame
+
+Column names reflect the chain under investigation. 
+- a : alpha
+- b : beta
+- g : gamma
+- d : delta
+
+One or more of the following columns are required and are case-sensitive  
+    - 'v_a_gene', 'v_b_gene', 'v_g_gene', or 'v_d_gene' 
+    - 'j_a_gene', 'j_b_gene', 'j_g_gene', or 'j_d_gene' 
+    - 'cdr3_a_aa', 'cdr3_b_aa', 'cdr3_g_aa', or  'cdr3a_d_aa'
+    - 'cdr3_a_nucseq', 'cdr3_b_nucseq, 'cdr3_g_nucseq', or 'cdr3a_d_nucseq' 
+
+.. tip::
+
+    Two of each can be supplied for paired analysis. tcrdistances can be calculated 
+    without nucleotide sequences, but most other features require them.
+
+
+The following is required.
+    - 'count'
+
+The following are optional:
+    - 'epitope`
+    - 'subject'
+
+
+The following are usually inferred from germline reference v-gene but can be supplied by the user in some advanced use-cases only!
+    -  'cdr1_a_aa', 'cdr1_b_aa',  'cdr1_g_aa',  or 'cdr1_d_aa'
+    -  'cdr2_a_aa', 'cdr2_b_aa',  'cdr2_g_aa',  or 'cdr2_d_aa'
+    -  'pmhc_a_aa', 'pmhc_a_aa',  'pmhc_a_aa',  or 'pmhc_a_aa' (pmhc = cdr 2.5)
+
+.. tip::
+
+  CDR2.5, the pMHC-facing loop between CDR2 and CDR3, are referred to in tcrdist2 as pmhc_a and phmc_b, respectively.
+
+
+Therefore, the typical input for beta-chain analysis would look like this:
+
++------------+------------+------------+------------+------------+----------------------+-----------------------------------------------------------+
+| subject    | epitope    | count      | v_b_gene   | j_b_gene   | cdr3_b_aa            | cdr3_b_nucseq                                             |
++============+============+============+============+============+======================+===========================================================+
+| s1         |   NP       |   1        | TRBV1*01   | TRBJ1-1*01 | CACDSLGDKSSWDTRQMFF  | TGTGCCTGTGACTCGCTGGGGGATAAGAGCTCCTGGGACACCCGACAGATGTTTTTC |
++------------+------------+------------+------------+------------+----------------------+-----------------------------------------------------------+			
+
+
+Arguments
++++++++++
+
+chain(s)
+-------
+
+Most classes and functions in tcrdist2 require specification of the appropriate t cell receptor 
+chains:
+    - ['alpha'], ['beta'], ['gamma'], or ['delta'] for single-chain analysis, 
+    - ['alpha', 'beta'] or ['gamma', 'delta'] for paired-chain analyis 
+
+organism
+--------
+
+Most classes and functions in tcrdist2 require specification of an appropriate host organism. 
+Currently only 'human' or 'mouse' are supported. This is required because reference TCR genes
+are organism specific. 
+
+db_file
+-------
+
+The `db_file` is used by tcrdist2 to supply updated information about reference TCR germline sequences. 
+
+These files come with tcrdist2:
+
+`tcrdist2/tcrdist/db/alphabeta_db.tsv`
+`tcrdist2/tcrdist/db/gammadelta_db.tsv`
+
+.. tip:: 
+
+    Getting new database files:
+    Reference json  https://github.com/repseqio/library-imgt/releases
+    `Data coming from IMGT server may be used for academic research only, provided that it is referred to IMGT®, and cited as "IMGT®, the international ImMunoGeneTics information system® http://www.imgt.org (founder and director: Marie-Paule Lefranc, Montpellier, France)."`

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -28,14 +28,24 @@ It should be placed the directory where you launch the installation.
 The following will install tcrdist on a linux or macOSX within a virtual
 environment (Recommended).
 
-If you are creating a virtual environment in Linux for the first time, the
+.. code-block:: none
+  
+  pip install wheel
+  pip install -r requirements36.txt
+  pip install git+https://github.com/kmayerb/tcrdist2.git@API2
+
+
+Virtual Env
++++++++++++
+
+You may want to use a virtual env to isolate tcrdist within its own environment.
+If you are creating a virtual environment on a Linux macine for the first time, the
 following preparatory steps may be required.
 
 .. code-block:: none
 
   apt-get python3-dev
   pip install virtualenv
-
 
 With virtualenv installed, continue with the installation:
 
@@ -82,72 +92,6 @@ To install blast within your virtual environment
 .. code-block:: none
 
   python -c "import tcrdist as td; td.setup_blast.install_blast_to_externals(download_from = 'ncbi_linux')"
-
-
-
-Dependencies if Using Python 2.7.11
-+++++++++++++++++++++++++++++++++++
-
-.. tip::
-
-  We are no longer supporting python 2.7. We have made extra effort to
-  update other code bases such as olga to run in python 3.6. Please contact
-  us if you have an urgent need for python 2.7 compatibility.
-
-If you are going to install the python 2.7.11 dependencies it is highly recommended that tcrdist2
-is installed within a `python virtual environment <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`_.
-Using a virtual environment isolates the program's dependencies so that
-installing legacy packages for python (2.7.11) -- numpy (1.10.1), scipy (0.16.0),
-scikit-learn (0.17.1), and matplotlib (1.4.3) --
-does not interfere with any of your other ongoing python projects.
-
-Setting up a virtual env takes less than 5 minutes using the commands below.
-
-To configure your machine to run tcrdist2 using the correct dependencies,
-use the `requirements.txt <https://github.com/kmayerb/tcrdist2/blob/API2/requirements.txt>`_
-file provided in the tcrdist2 github repository.
-
-With python 2.7.11, pip, virtualenv already installed:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: none
-
-  virtualenv venv
-  source ./venv/bin/activate
-  pip install -r requirements.txt
-  pip install git+https://github.com/kmayerb/tcrdist2.git@API2
-
-
-
-Using Conda to install python 2.7.11, pip, and virtualenv
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The instructions below assume that you have a working version of condas
-installed or can install python 2.7.11 by other means.
-
-.. code-block:: none
-
-  conda create -n py27v python=2.7.11 pip virtualenv
-  conda activate py27v
-  virtualenv venv
-  conda deactivate
-  conda deactivate
-  source ./venv/bin/activate
-  pip install -r requirements.txt
-  pip install git+https://github.com/kmayerb/tcrdist2.git@API2
-
-
-#. Using condas, install a base python interpretor (Python version 2.7.11) with pip and virtualenv.
-   **conda create -n py27v python=2.7.11 pip virtualenv**
-#. Activate it: **conda activate py27v**
-#. Make a virtual env that will contain all of tcrdists dependencies: **virtualenv venv**
-#. Deactivate condas env (twice to deactivate py27v and base) : **conda deactivate**
-#. Source venv : **source ./venv/bin/activate.**
-#. pip install all tcrdists dependencies **pip install -r requirements.txt**
-   (download `requirements.txt <https://github.com/kmayerb/tcrdist2/blob/API2/requirements.txt>`_
-   and place it in your working directory)
-#. pip install tcrdist2 from GitHub **pip install git+https://github.com/kmayerb/tcrdist2.git@API2**
-#. OPTIONAL: Install Blast Tools (see section below)
 
 
 Optional Blast Tools

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ role in epitope specificity (see Methods and Extended Data Fig. 3)."
    :maxdepth: 2
 
    Installation
+   Inputs
    CompleteExample
    Saving
    Plotting

--- a/tcrdist/repertoire.py
+++ b/tcrdist/repertoire.py
@@ -166,7 +166,22 @@ class TCRrep:
         result to attribute self.clone_df
         """
         self.clone_df = _deduplicate(self.cell_df, self.index_cols)
+        
+        # check if any clones were lost due to missing information
+        if np.sum(self.cell_df['count']) != np.sum(self.clone_df['count']):
+            n_cells_lost = np.sum(self.cell_df['count']) - np.sum(self.clone_df['count'])
+            n_cell = np.sum(self.cell_df['count'])
+            warnings.warn("Not all cells/sequences could be grouped into clones.\n")
+            warnings.warn(f"{n_cells_lost} of {n_cell} were not captured. This occurs when any\n") 
+            warnings.warn("of the values in the index columns are null or missing for a given sequence.\n")
+            warnings.warn("To see entries with missing values use: tcrdist.repertoire.TCRrep.show_incomplete()\n")
+        
         return self
+
+    def show_incomplete(self):      
+        ind = self.cell_df[self.index_cols].isnull().any(axis = 1)   
+        incomplete_clones = self.cell_df.loc[ind,self.index_cols].copy()
+        return incomplete_clones  
 
     # def tcr_motif_clones_df(self):
     #     """

--- a/tcrdist/tests/test_repertoire_more.py
+++ b/tcrdist/tests/test_repertoire_more.py
@@ -1,0 +1,53 @@
+"""
+This test page is for unit tests associated with TCRrep operations. 
+As opposed to test_repertoire.py these should be exceptionally short unit tests. 
+
+
+"""
+from tcrdist.repertoire import TCRrep
+import pytest
+import pandas as pd
+import numpy as np
+
+def test_TCRrep_deduplicate_gives_warning_above_complete_values():
+    """
+    Warn user if there is missing value in an index column and cell count will not match clone count
+    """
+    df= pd.DataFrame({"cdr3_a_aa" : ["A","B","C"], 
+                        "v_a_gene"  : ["TRAV1*01","TRAV1*01",None],
+                        "count"     : [1,1,1]}) 
+    tr = TCRrep(cell_df = df, organism = "human", chains = ["alpha"])
+    tr.index_cols = ['cdr3_a_aa', 'v_a_gene'] 
+    with pytest.warns(None) as record:
+        tr.deduplicate()
+    assert len(record) == 4
+    assert str(record[0].message) == "Not all cells/sequences could be grouped into clones.\n"
+    
+def test_TCRrep_show_incomplete_entries():
+    """
+    Test that show TCRrep method returns rows with some missing attribute
+    """
+    df= pd.DataFrame({"cdr3_a_aa" : ["A","B","C"], 
+                      "v_a_gene"  : ["TRAV1*01","TRAV1*01",None],
+                      "count"     : [1,1,1]}) 
+    tr = TCRrep(cell_df = df, organism = "human", chains = ["alpha"])
+    tr.index_cols = ['cdr3_a_aa', 'v_a_gene'] 
+    dfi = tr.show_incomplete()
+    assert isinstance(dfi, pd.DataFrame)
+    assert dfi.to_dict() ==  {'cdr3_a_aa': {2: 'C'}, 'v_a_gene': {2: None}}  
+
+def test_TCRrep_show_incomplete_entries_when_there_are_none():
+    """
+    Test that show TCRrep method returns rows with some missing attribute
+    """
+    df= pd.DataFrame({"cdr3_a_aa" : ["A","B","C"], 
+                      "v_a_gene"  : ["TRAV1*01","TRAV1*01","TRAV1*01"],
+                      "count"     : [1,1,1]}) 
+    tr = TCRrep(cell_df = df, organism = "human", chains = ["alpha"])
+    tr.index_cols = ['cdr3_a_aa', 'v_a_gene'] 
+    dfi = tr.show_incomplete()
+    assert isinstance(dfi, pd.DataFrame)
+    assert dfi.shape[0] == 0
+    assert dfi.shape[1] == 2
+    #assert dfi.to_dict() ==  {'cdr3_a_aa': {2: 'C'}, 'v_a_gene': {2: None}}   
+    


### PR DESCRIPTION
This pull request adds a warning message to the TCRrep.dedupicate function to tell the user if any of the seq/cell entries have Null values in the group by index columns. This behavior can lead to cases where cells are not counted as part of clones because some piece of information is not available such as a gene name.

The PR also adds the function TCRrep.show_incomplete() that allows the user to see these seq/cells that would be dropped. 

Three basic tests are added.

For more on this issue see" https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html#na-values-in-groupby

I am noticing that when pandas attempts to groupby and a column used to groupby contains some NA values, those entries with any NaN are dropped. 

